### PR TITLE
Another attempt at smoothing lighting with Sodium 0.5.x

### DIFF
--- a/src/main/java/dev/lambdaurora/lambdynlights/mixin/sodium/ArrayLightDataCacheMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/mixin/sodium/ArrayLightDataCacheMixin.java
@@ -13,7 +13,6 @@ import dev.lambdaurora.lambdynlights.LambDynLights;
 import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
-import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
@@ -51,7 +50,7 @@ public abstract class ArrayLightDataCacheMixin extends LightDataAccess {
         // repack new dynamic lighting if necessary (no lightmaps, just straight light and luminance)
         if (dynamic_precise_light > block_light) {
             // I'm not super familiar with LambDynamicLights codebase, but this seems close to old lightmap behaviour
-            int dynamic_light = (int) (MathHelper.ceil(dynamic_precise_light));
+            int dynamic_light = (int) dynamic_precise_light;
             int dynamic_luminance = dynamic_light;  // if this is right then this could be optimized out
 
             // It would be nice if sodium provided LightDataAccess.wipeBL(), wipeLU(), etc for efficiency.

--- a/src/main/java/dev/lambdaurora/lambdynlights/mixin/sodium/ArrayLightDataCacheMixin.java
+++ b/src/main/java/dev/lambdaurora/lambdynlights/mixin/sodium/ArrayLightDataCacheMixin.java
@@ -13,6 +13,7 @@ import dev.lambdaurora.lambdynlights.LambDynLights;
 import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockRenderView;
+import net.minecraft.util.math.MathHelper;
 import org.spongepowered.asm.mixin.Dynamic;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Pseudo;
@@ -33,22 +34,34 @@ public abstract class ArrayLightDataCacheMixin extends LightDataAccess {
     @Dynamic
     @Inject(method = "get(III)I", at = @At("RETURN"), cancellable = true)
     private void lambdynlights$modifyBlockLight(int x, int y, int z, CallbackInfoReturnable<Integer> cir) {
+        if ( ! LambDynLights.get().config.getDynamicLightsMode().isEnabled() )
+          return;  // early out if disabled
+
         this.lambdynlights$pos.set(x, y, z);
 
-        BlockRenderView world = this.world;
-
-        // Use Sodium's provided unpack method in case the format ever changes.
+        // Sodium's new packed format allows us to introspect lots of a data in one integer.
+        // This means we can skip getting access to world in this context.
         int packed = cir.getReturnValueI();
-        int original = LightDataAccess.unpackBL(packed);
+        boolean fullopaque = LightDataAccess.unpackFO(packed);
+        if ( fullopaque ) return;  // early out if block is full opaque
 
-        if (!world.getBlockState(this.lambdynlights$pos).isOpaqueFullCube(world, this.lambdynlights$pos) && LambDynLights.get().config.getDynamicLightsMode().isEnabled()) {
-            int dynamic = (int) LambDynLights.get().getDynamicLightLevel(this.lambdynlights$pos);
-            if (dynamic > original) {
-                // Remove the original block light value from the packed value,
-                // then add the dynamic packed value in.
-                // TODO: maybe the repacking of the original can be avoided somehow?
-                cir.setReturnValue((packed & ~(LightDataAccess.packBL(original))) | LightDataAccess.packBL(dynamic));
-            }
+        double dynamic_precise_light = LambDynLights.get().getDynamicLightLevel(this.lambdynlights$pos);
+        int block_light = LightDataAccess.unpackBL(packed);
+
+        // repack new dynamic lighting if necessary (no lightmaps, just straight light and luminance)
+        if (dynamic_precise_light > block_light) {
+            // I'm not super familiar with LambDynamicLights codebase, but this seems close to old lightmap behaviour
+            int dynamic_light = (int) (MathHelper.ceil(dynamic_precise_light));
+            int dynamic_luminance = dynamic_light;  // if this is right then this could be optimized out
+
+            // It would be nice if sodium provided LightDataAccess.wipeBL(), wipeLU(), etc for efficiency.
+            // It would remove the need for unpacking and repacking to guarantee the right bitwise action.
+            int block_luminance = LightDataAccess.unpackLU(packed);
+            cir.setReturnValue(packed & ~(LightDataAccess.packBL(block_light) | LightDataAccess.packLU(block_luminance))
+                                      | LightDataAccess.packBL(dynamic_light) | LightDataAccess.packLU(dynamic_luminance));
+            // would become this:
+            // cir.setReturnValue((packed & ~(LightDataAccess.wipeBL() | LightDataAccess.wipeLU()))
+            //                            | LightDataAccess.packBL(dynamic_light) | LightDataAccess.packLU(dynamic_luminance);
         }
     }
 }


### PR DESCRIPTION
Hey, I was poking a bit deeper at the way the new LightDataAccess works in Sodium 5.0.x.  I noticed you already have a open pull request with LambdAurora and have also done most of the heavy lifting, so I figured it would make more sense to push my alterations onto your branch if you approve.

I modified what you had done to try and update both block light and luminance with a couple of optimizations I could squeeze in with the increased information available from Sodium.  I'm uncertain if it is exactly right to the way the old lightmap code worked, but I think it's pretty close.